### PR TITLE
결제 이력 로그파일 저장 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,4 @@ docker/es
 app/src/main/resources/static/
 
 app/src/main/resources/application-*
+logs/

--- a/app/src/main/resources/logback-spring.xml
+++ b/app/src/main/resources/logback-spring.xml
@@ -1,0 +1,38 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/application.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/application-%d{yyyy.MM.dd}.log.gz</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="PAYMENT_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/payment.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/payment-%d{yyyy.MM.dd}.log.gz</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
+    </root>
+
+    <logger name="org.springframework" level="INFO"/>
+    <logger name="payment" level="INFO" additivity="false">
+        <appender-ref ref="PAYMENT_FILE" />
+    </logger>
+</configuration>

--- a/app/src/main/resources/logback-spring.xml
+++ b/app/src/main/resources/logback-spring.xml
@@ -32,7 +32,7 @@
     </root>
 
     <logger name="org.springframework" level="INFO"/>
-    <logger name="payment" level="INFO" additivity="false">
+    <logger name="org.collaborators.paymentslab" level="INFO" additivity="false">
         <appender-ref ref="PAYMENT_FILE" />
     </logger>
 </configuration>

--- a/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/DefaultPaymentsProcessor.kt
+++ b/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/DefaultPaymentsProcessor.kt
@@ -1,23 +1,30 @@
 package org.collaborators.paymentslab.payment.infrastructure.tosspayments
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.collaborator.paymentlab.common.AuthenticatedUser
 import org.collaborators.paymentslab.payment.domain.PaymentHistory
 import org.collaborators.paymentslab.payment.domain.PaymentHistoryRepository
 import org.collaborators.paymentslab.payment.domain.PaymentsProcessor
 import org.collaborators.paymentslab.payment.domain.TossPaymentsRepository
+import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.transaction.annotation.Transactional
 
-class DefaultPaymentsProcessor(
+open class DefaultPaymentsProcessor(
     private val tossPaymentsKeyInApprovalProcessor: TossPaymentsKeyInApprovalProcessor,
     private val tossPaymentsRepository: TossPaymentsRepository,
 
     // TODO 결제이력 eventListener 구현 이후 삭제
     private val paymentHistoryRepository: PaymentHistoryRepository,
 
-    private val publisher: ApplicationEventPublisher
+    private val publisher: ApplicationEventPublisher,
+    private val objectMapper: ObjectMapper
 ): PaymentsProcessor {
 
+    private val logger = LoggerFactory.getLogger("org.collaborators.paymentslab")
+
+    @Transactional
     override fun keyInPay(
         amount: Int,
         orderId: String,
@@ -47,8 +54,11 @@ class DefaultPaymentsProcessor(
         newPaymentEntity.completeOf(principal.id)
         val newPaymentRecord = tossPaymentsRepository.save(newPaymentEntity)
 
+        logger.info("complete {}", objectMapper.writeValueAsString(newPaymentRecord))
         val newPaymentHistoryEntity = PaymentHistory.newInstanceFrom(newPaymentRecord)
         paymentHistoryRepository.save(newPaymentHistoryEntity)
+        logger.info("history {}",objectMapper.writeValueAsString(newPaymentHistoryEntity))
+
         // TODO EventListener 를 활용하여, 비동기로 결제이력 저장하는 코드 작성
 //        newPaymentRecord.pollAllEvents().forEach { publisher.publishEvent(it) }
     }


### PR DESCRIPTION
**이 기능이 필요한 이유**
db 서버가 다운되어 결제 이력이 누락되었거나, 오히려 중복이 우려되었을때, 로그 파일의 내용과 크로스 체크를 하여 정해진 일정마다 동기화를 진행할 필요가 있다.

결제 완료와 결제 이력을 따로 저장하였는데, 추후에 결제 완료 알림과 결제 이력 저장 기능이 1:1로 진행되었는지 검증하는데 사용될 수 있다.

**채택한 방법**
기존의 spring 프레임워크에서 제공하는 logback 설정을 활용하여, 애플리케이션에서 출력하는 기본 로그외로 별도로 결제 완료 및 결제 이력 저장관련 데이터를 로그 파일에 건별로 저장하는 방법으로 진행함.

**해당 방법을 채택한 이유**
디스크의 용량은 한정되어 있기 때문에 로그를 저장 및 관리하는 정책이 필요하다. 그러한 정책을 검증되고 간단한 방법으로 제어할 수 있는 방법을 활용해야 유지보수 비용을 줄일 수 있을거라 생각했다.