### PR TITLE
주문 결제 발행 api 구현

### DIFF
--- a/account-api/account-application/src/main/kotlin/org/collaborators/paymentslab/account/application/AccountService.kt
+++ b/account-api/account-application/src/main/kotlin/org/collaborators/paymentslab/account/application/AccountService.kt
@@ -44,7 +44,7 @@ class AccountService(
         return TokenDto(tokens.accessToken, tokens.refreshToken)
     }
 
-    fun validateWithPhoneNumber(phoneNumber: String) {
+    fun validate(phoneNumber: String) {
         accountValidator.validate(phoneNumber)
     }
 

--- a/account-api/account-presentation/src/main/kotlin/org/collaborators/paymentslab/account/presentation/AccountApi.kt
+++ b/account-api/account-presentation/src/main/kotlin/org/collaborators/paymentslab/account/presentation/AccountApi.kt
@@ -17,7 +17,7 @@ class AccountApi(private val accountService: AccountService) {
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @GetMapping("phone")
     fun validateAccountByPhoneNumber(@RequestBody @Valid request: AccountPhoneNumberRequest) {
-        accountService.validateWithPhoneNumber(request.phoneNumber)
+        accountService.validate(request.phoneNumber)
     }
 
 }

--- a/account-api/account-presentation/src/main/kotlin/org/collaborators/paymentslab/account/presentation/AccountApi.kt
+++ b/account-api/account-presentation/src/main/kotlin/org/collaborators/paymentslab/account/presentation/AccountApi.kt
@@ -1,6 +1,7 @@
 package org.collaborators.paymentslab.account.presentation
 
 import jakarta.validation.Valid
+import org.collaborator.paymentlab.common.V1_API_ACCOUNT
 import org.collaborators.paymentslab.account.application.AccountService
 import org.collaborators.paymentslab.account.presentation.request.AccountPhoneNumberRequest
 import org.springframework.security.access.prepost.PreAuthorize
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("api/v1/account")
+@RequestMapping(V1_API_ACCOUNT)
 class AccountApi(private val accountService: AccountService) {
 
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")

--- a/account-api/account-presentation/src/main/kotlin/org/collaborators/paymentslab/account/presentation/AuthenticationApi.kt
+++ b/account-api/account-presentation/src/main/kotlin/org/collaborators/paymentslab/account/presentation/AuthenticationApi.kt
@@ -1,6 +1,7 @@
 package org.collaborators.paymentslab.account.presentation
 
 import jakarta.validation.Valid
+import org.collaborator.paymentlab.common.V1_API_AUTH
 import org.collaborator.paymentlab.common.result.ApiResult
 import org.collaborators.paymentslab.account.application.AccountService
 import org.collaborators.paymentslab.account.application.command.LoginAccount
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.*
 import java.net.URI
 
 @RestController
-@RequestMapping("api/v1/auth")
+@RequestMapping(V1_API_AUTH)
 class AuthenticationApi(private val accountService: AccountService) {
 
     @PostMapping("register")

--- a/app/src/docs/asciidoc/payments.adoc
+++ b/app/src/docs/asciidoc/payments.adoc
@@ -23,3 +23,17 @@ include::{snippets}/payment-api-test/card-num-error-key-in/http-response.adoc[]
 include::{snippets}/payment-api-test/read-histories-test/http-request.adoc[]
 ==== HTTP response
 include::{snippets}/payment-api-test/read-histories-test/http-response.adoc[]
+
+=== 토스 주문 결제 발행 api
+
+==== HTTP request
+include::{snippets}/payment-api-test/test-generate-payment-order/http-request.adoc[]
+==== HTTP response
+include::{snippets}/payment-api-test/test-generate-payment-order/http-response.adoc[]
+
+=== 토스 주문 결제 발행 오류 api
+
+==== HTTP request
+include::{snippets}/payment-api-test/test-with-invalid-account-generate-payment-order/http-request.adoc[]
+==== HTTP response
+include::{snippets}/payment-api-test/test-with-invalid-account-generate-payment-order/http-response.adoc[]

--- a/app/src/main/kotlin/org/collaborators/paymentslab/config/security/SecurityConfig.kt
+++ b/app/src/main/kotlin/org/collaborators/paymentslab/config/security/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package org.collaborators.paymentslab.config.security
 
+import org.collaborator.paymentlab.common.V1_API_AUTH
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -48,9 +49,9 @@ class SecurityConfig(
             .and()
             .authorizeHttpRequests()
             .requestMatchers(GET, "/", "/index.html").permitAll()
-            .requestMatchers(POST,"/api/v1/auth/register").permitAll()
-            .requestMatchers(POST,"/api/v1/auth/login").permitAll()
-            .requestMatchers(GET, "/api/v1/auth/confirm").permitAll()
+            .requestMatchers(POST,"$V1_API_AUTH/register").permitAll()
+            .requestMatchers(POST,"$V1_API_AUTH/login").permitAll()
+            .requestMatchers(GET, "$V1_API_AUTH/confirm").permitAll()
             .anyRequest().authenticated()
             .and()
             .formLogin().disable()

--- a/app/src/main/kotlin/org/collaborators/paymentslab/config/security/SecurityConfig.kt
+++ b/app/src/main/kotlin/org/collaborators/paymentslab/config/security/SecurityConfig.kt
@@ -1,6 +1,8 @@
 package org.collaborators.paymentslab.config.security
 
 import org.collaborator.paymentlab.common.V1_API_AUTH
+import org.collaborator.paymentlab.common.V1_API_TOSS_PAYMENTS
+import org.collaborator.paymentlab.common.V1_TOSS_PAYMENTS
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -49,6 +51,7 @@ class SecurityConfig(
             .and()
             .authorizeHttpRequests()
             .requestMatchers(GET, "/", "/index.html").permitAll()
+            .requestMatchers(GET, V1_TOSS_PAYMENTS).permitAll()
             .requestMatchers(POST,"$V1_API_AUTH/register").permitAll()
             .requestMatchers(POST,"$V1_API_AUTH/login").permitAll()
             .requestMatchers(GET, "$V1_API_AUTH/confirm").permitAll()

--- a/app/src/main/resources/logback-spring.xml
+++ b/app/src/main/resources/logback-spring.xml
@@ -6,7 +6,6 @@
         <file>logs/application.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/application-%d{yyyy.MM.dd}.log.gz</fileNamePattern>
-            <maxHistory>30</maxHistory>
         </rollingPolicy>
 
         <encoder>

--- a/app/src/main/resources/templates/purchase.html
+++ b/app/src/main/resources/templates/purchase.html
@@ -8,7 +8,7 @@
 <body>
     <form id = "paymentOrderForm" action="/" method="post">
         <label for = "orderName">상품명:</label>
-        <input type = "text" id = "orderName" name="orderName" value="테스트 상품 결제주문 발행" readonly><br><br>
+        <input type = "text" id = "orderName" name="orderName" value="테스트 상품 결제주문 발행"><br><br>
 
         <label for = "amount">수량:</label>
         <input type = "number" id = "amount" name = "amount" min = "1" value = "1"><br><br>
@@ -24,6 +24,7 @@
             formData.forEach((value, key) => {
                 jsonObject[key] = value;
             });
+            jsonObject["accountId"] = 1; // jwt account id
 
             const xhr = new XMLHttpRequest();
             xhr.open("POST", "http://localhost:8080/v1/api/toss-payments/payment-order", true);

--- a/app/src/main/resources/templates/purchase.html
+++ b/app/src/main/resources/templates/purchase.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>결제 주문 페이지</title>
+</head>
+<body>
+    <form id = "paymentOrderForm" action="/" method="post">
+        <label for = "orderName">상품명:</label>
+        <input type = "text" id = "orderName" name="orderName" value="테스트 상품 결제주문 발행" readonly><br><br>
+
+        <label for = "amount">수량:</label>
+        <input type = "number" id = "amount" name = "amount" min = "1" value = "1"><br><br>
+
+        <input type = "submit" value = "바로 구매하기">
+    </form>
+    <script type = "text/javascript">
+        function sendFormData() {
+            const form = document.getElementById("paymentOrderForm");
+            const formData = new FormData(form);
+
+            const jsonObject = {};
+            formData.forEach((value, key) => {
+                jsonObject[key] = value;
+            });
+
+            const xhr = new XMLHttpRequest();
+            xhr.open("POST", "http://localhost:8080/v1/api/toss-payments/payment-order", true);
+            xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+            xhr.setRequestHeader("Authorization", `Bearer ${localStorage.getItem('token')}`);
+            xhr.onreadystatechange = () => {
+                if (xhr.readyState === 4 && xhr.status === 200) {
+                    alert("요청이 성공적으로 완료되었습니다.");
+                } else if (xhr.readyState === 4) {
+                    alert("요청이 실패했습니다. 상태 코드: " + xhr.status);
+                }
+            };
+           xhr.send(JSON.stringify(jsonObject));
+        }
+
+        document.getElementById("paymentOrderForm").addEventListener("submit", function(event) {
+            event.preventDefault();
+            sendFormData();
+        });
+    </script>
+</body>
+</html>

--- a/app/src/test/kotlin/org/collaborators/paymentslab/account/presentation/AuthenticationApiTest.kt
+++ b/app/src/test/kotlin/org/collaborators/paymentslab/account/presentation/AuthenticationApiTest.kt
@@ -1,5 +1,6 @@
 package org.collaborators.paymentslab.account.presentation
 
+import org.collaborator.paymentlab.common.V1_API_AUTH
 import org.collaborators.paymentslab.AbstractApiTest
 import org.collaborators.paymentslab.account.domain.Account
 import org.collaborators.paymentslab.account.domain.AccountRepository
@@ -31,7 +32,7 @@ class AuthenticationApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/auth/register")
+                .post("$V1_API_AUTH/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -69,7 +70,7 @@ class AuthenticationApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/auth/register")
+                .post("$V1_API_AUTH/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -110,7 +111,7 @@ class AuthenticationApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/auth/register")
+                .post("$V1_API_AUTH/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -155,7 +156,7 @@ class AuthenticationApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .get("/api/v1/auth/confirm")
+                .get("$V1_API_AUTH/confirm")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -188,7 +189,7 @@ class AuthenticationApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/auth/login")
+                .post("$V1_API_AUTH/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -235,7 +236,7 @@ class AuthenticationApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/auth/login")
+                .post("$V1_API_AUTH/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -267,7 +268,7 @@ class AuthenticationApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/auth/reIssuance")
+                .post("$V1_API_AUTH/reIssuance")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer ${tokens.refreshToken}")
@@ -305,7 +306,7 @@ class AuthenticationApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/auth/reIssuance")
+                .post("$V1_API_AUTH/reIssuance")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer ${tokens.refreshToken}")
@@ -330,7 +331,7 @@ class AuthenticationApiTest @Autowired constructor(
     fun expiredReIssuanceTest() {
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/auth/reIssuance")
+                .post("$V1_API_AUTH/reIssuance")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer ${MockAuthentication.expiredRefreshToken}")

--- a/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApiTest.kt
+++ b/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApiTest.kt
@@ -352,7 +352,6 @@ class PaymentApiTest @Autowired constructor(
 
     // 임시로 비활성화
     @Test
-    @Disabled
     @DisplayName("변조된 사용자 계정 id로 주문 결제 발행 api 테스트")
     fun testWithInvalidAccountGeneratePaymentOrder() {
         val account = testEntityForRegister("originalGeneratedPaymentOrder@gmail.com")

--- a/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApiTest.kt
+++ b/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApiTest.kt
@@ -277,7 +277,7 @@ class PaymentApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .get("/api/v1/toss-payments")
+                .get(V1_API_TOSS_PAYMENTS)
                 .param("pageNum", "0")
                 .param("pageSize", "6")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApiTest.kt
+++ b/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApiTest.kt
@@ -1,6 +1,7 @@
 package org.collaborators.paymentslab.payment.presentation
 
 import org.collaborator.paymentlab.common.Role
+import org.collaborator.paymentlab.common.V1_API_TOSS_PAYMENTS
 import org.collaborators.paymentslab.AbstractApiTest
 import org.collaborators.paymentslab.account.domain.AccountRepository
 import org.collaborators.paymentslab.payment.domain.entity.PaymentHistory
@@ -49,7 +50,7 @@ class PaymentApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/toss-payments/key-in/{paymentOrderId}", paymentOrder.id)
+                .post("$V1_API_TOSS_PAYMENTS/key-in/{paymentOrderId}", paymentOrder.id)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -85,7 +86,7 @@ class PaymentApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/toss-payments/key-in/{paymentOrderId}", paymentOrder.id)
+                .post("$V1_API_TOSS_PAYMENTS/key-in/{paymentOrderId}", paymentOrder.id)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -122,7 +123,7 @@ class PaymentApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/toss-payments/key-in/{paymentOrderId}", 99L)
+                .post("$V1_API_TOSS_PAYMENTS/key-in/{paymentOrderId}", 99L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -161,7 +162,7 @@ class PaymentApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/toss-payments/key-in/{paymentOrderId}", paymentOrder.id)
+                .post("$V1_API_TOSS_PAYMENTS/key-in/{paymentOrderId}", paymentOrder.id)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -199,7 +200,7 @@ class PaymentApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/toss-payments/key-in/{paymentOrderId}", paymentOrder.id)
+                .post("$V1_API_TOSS_PAYMENTS/key-in/{paymentOrderId}", paymentOrder.id)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -236,7 +237,7 @@ class PaymentApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/toss-payments/key-in/{paymentOrderId}", paymentOrder.id)
+                .post("$V1_API_TOSS_PAYMENTS/key-in/{paymentOrderId}", paymentOrder.id)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -323,7 +324,7 @@ class PaymentApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/toss-payments/payment-order")
+                .post("$V1_API_TOSS_PAYMENTS/payment-order")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)
@@ -360,7 +361,7 @@ class PaymentApiTest @Autowired constructor(
 
         this.mockMvc.perform(
             RestDocumentationRequestBuilders
-                .post("/api/v1/toss-payments/payment-order")
+                .post("$V1_API_TOSS_PAYMENTS/payment-order")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(reqBody)

--- a/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApiTest.kt
+++ b/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApiTest.kt
@@ -11,6 +11,7 @@ import org.collaborators.paymentslab.payment.domain.repository.PaymentHistoryRep
 import org.collaborators.paymentslab.payment.domain.repository.PaymentOrderRepository
 import org.collaborators.paymentslab.payment.presentation.mock.MockPayments
 import org.collaborators.paymentslab.payment.presentation.request.PaymentOrderRequest
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -349,7 +350,9 @@ class PaymentApiTest @Autowired constructor(
             )
     }
 
+    // 임시로 비활성화
     @Test
+    @Disabled
     @DisplayName("변조된 사용자 계정 id로 주문 결제 발행 api 테스트")
     fun testWithInvalidAccountGeneratePaymentOrder() {
         val account = testEntityForRegister("originalGeneratedPaymentOrder@gmail.com")

--- a/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/mock/MockPaymentService.kt
+++ b/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/mock/MockPaymentService.kt
@@ -2,6 +2,7 @@ package org.collaborators.paymentslab.payment.presentation.mock
 
 import org.collaborators.paymentslab.payment.application.PaymentService
 import org.collaborators.paymentslab.payment.application.command.TossPaymentsKeyInPayCommand
+import org.collaborators.paymentslab.payment.domain.PaymentOrderProcessor
 import org.collaborators.paymentslab.payment.domain.PaymentsProcessor
 import org.collaborators.paymentslab.payment.domain.PaymentsQueryManager
 import org.collaborators.paymentslab.payment.domain.repository.PaymentOrderRepository
@@ -17,9 +18,10 @@ import org.springframework.transaction.annotation.Transactional
 class MockPaymentService(
     private val paymentsProcessor: PaymentsProcessor,
     private val paymentsQueryManager: PaymentsQueryManager,
+    private val paymentOrderProcessor: PaymentOrderProcessor,
     private val paymentOrderRepository: PaymentOrderRepository,
     private val tossPaymentsValidator: TossPaymentsValidator
-): PaymentService(paymentsProcessor, paymentsQueryManager) {
+): PaymentService(paymentsProcessor, paymentOrderProcessor, paymentsQueryManager) {
     override fun keyInPay(paymentOrderId: Long, command: TossPaymentsKeyInPayCommand) {
         val paymentOrder = paymentOrderRepository.findById(paymentOrderId)
         tossPaymentsValidator.validate(paymentOrder, command.amount, command.orderName)

--- a/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/mock/MockPaymentService.kt
+++ b/app/src/test/kotlin/org/collaborators/paymentslab/payment/presentation/mock/MockPaymentService.kt
@@ -18,10 +18,9 @@ import org.springframework.transaction.annotation.Transactional
 class MockPaymentService(
     private val paymentsProcessor: PaymentsProcessor,
     private val paymentsQueryManager: PaymentsQueryManager,
-    private val paymentOrderProcessor: PaymentOrderProcessor,
     private val paymentOrderRepository: PaymentOrderRepository,
     private val tossPaymentsValidator: TossPaymentsValidator
-): PaymentService(paymentsProcessor, paymentOrderProcessor, paymentsQueryManager) {
+): PaymentService(paymentsProcessor, paymentsQueryManager) {
     override fun keyInPay(paymentOrderId: Long, command: TossPaymentsKeyInPayCommand) {
         val paymentOrder = paymentOrderRepository.findById(paymentOrderId)
         tossPaymentsValidator.validate(paymentOrder, command.amount, command.orderName)

--- a/common/src/main/kotlin/org/collaborator/paymentlab/common/Constants.kt
+++ b/common/src/main/kotlin/org/collaborator/paymentlab/common/Constants.kt
@@ -4,3 +4,8 @@ package org.collaborator.paymentlab.common
 const val URI_SCHEME = "http"
 const val URI_HOST = "127.0.0.1"
 const val URI_PORT = 8080
+
+// API SIGNATURE
+const val V1_API_ACCOUNT = "/v1/api/account"
+const val V1_API_AUTH = "/v1/api/auth"
+const val V1_API_TOSS_PAYMENTS = "/v1/api/toss-payments"

--- a/common/src/main/kotlin/org/collaborator/paymentlab/common/Constants.kt
+++ b/common/src/main/kotlin/org/collaborator/paymentlab/common/Constants.kt
@@ -9,3 +9,6 @@ const val URI_PORT = 8080
 const val V1_API_ACCOUNT = "/v1/api/account"
 const val V1_API_AUTH = "/v1/api/auth"
 const val V1_API_TOSS_PAYMENTS = "/v1/api/toss-payments"
+
+// FRONT PAGE SIGNATURE(TEMP)
+const val V1_TOSS_PAYMENTS = "/v1/toss-payments"

--- a/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentOrderService.kt
+++ b/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentOrderService.kt
@@ -1,0 +1,16 @@
+package org.collaborators.paymentslab.payment.application
+
+import org.collaborators.paymentslab.payment.application.command.PaymentOrderCommand
+import org.collaborators.paymentslab.payment.domain.PaymentOrderProcessor
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class PaymentOrderService(
+    private val paymentOrderProcessor: PaymentOrderProcessor,
+) {
+    fun generate(command: PaymentOrderCommand): String {
+        return paymentOrderProcessor.process(command.accountId, command.orderName, command.amount)
+    }
+}

--- a/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentService.kt
+++ b/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentService.kt
@@ -43,7 +43,6 @@ class PaymentService(
     }
 
     fun generatePaymentOrder(command: PaymentOrderCommand): String {
-        // TODO 프론트에 리액트를 적용하기 전까지는 임시로 accountId 검증은 비활성화
         return paymentOrderProcessor.process(command.accountId, command.orderName, command.amount)
     }
 }

--- a/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentService.kt
+++ b/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentService.kt
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class PaymentService(
     private val paymentsProcessor: PaymentsProcessor,
-    private val paymentOrderProcessor: PaymentOrderProcessor,
     private val paymentsQueryManager: PaymentsQueryManager
     ) {
 
@@ -40,9 +39,5 @@ class PaymentService(
         val entities = paymentsQueryManager.queryHistory(
             query.pageNum, query.pageSize, query.direction, query.properties)
         return entities.map { PaymentHistoryQueryQueryModel.of(it) }
-    }
-
-    fun generatePaymentOrder(command: PaymentOrderCommand): String {
-        return paymentOrderProcessor.process(command.accountId, command.orderName, command.amount)
     }
 }

--- a/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentService.kt
+++ b/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentService.kt
@@ -43,6 +43,7 @@ class PaymentService(
     }
 
     fun generatePaymentOrder(command: PaymentOrderCommand): String {
-        return paymentOrderProcessor.process(command.accountId, command.orderName, command.amount)
+        // TODO 프론트에 리액트를 적용하기 전까지는 임시로 accountId 검증은 비활성화
+        return paymentOrderProcessor.process(command.orderName, command.amount)
     }
 }

--- a/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentService.kt
+++ b/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentService.kt
@@ -1,8 +1,10 @@
 package org.collaborators.paymentslab.payment.application
 
+import org.collaborators.paymentslab.payment.application.command.PaymentOrderCommand
 import org.collaborators.paymentslab.payment.application.command.TossPaymentsKeyInPayCommand
 import org.collaborators.paymentslab.payment.application.query.PaymentHistoryQuery
 import org.collaborators.paymentslab.payment.application.query.PaymentHistoryQueryQueryModel
+import org.collaborators.paymentslab.payment.domain.PaymentOrderProcessor
 import org.collaborators.paymentslab.payment.domain.PaymentsProcessor
 import org.collaborators.paymentslab.payment.domain.PaymentsQueryManager
 import org.springframework.context.annotation.Profile
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class PaymentService(
     private val paymentsProcessor: PaymentsProcessor,
+    private val paymentOrderProcessor: PaymentOrderProcessor,
     private val paymentsQueryManager: PaymentsQueryManager
     ) {
 
@@ -37,5 +40,9 @@ class PaymentService(
         val entities = paymentsQueryManager.queryHistory(
             query.pageNum, query.pageSize, query.direction, query.properties)
         return entities.map { PaymentHistoryQueryQueryModel.of(it) }
+    }
+
+    fun generatePaymentOrder(command: PaymentOrderCommand): String {
+        return paymentOrderProcessor.process(command.accountId, command.orderName, command.amount)
     }
 }

--- a/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentService.kt
+++ b/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/PaymentService.kt
@@ -44,6 +44,6 @@ class PaymentService(
 
     fun generatePaymentOrder(command: PaymentOrderCommand): String {
         // TODO 프론트에 리액트를 적용하기 전까지는 임시로 accountId 검증은 비활성화
-        return paymentOrderProcessor.process(command.orderName, command.amount)
+        return paymentOrderProcessor.process(command.accountId, command.orderName, command.amount)
     }
 }

--- a/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/command/PaymentOrderCommand.kt
+++ b/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/command/PaymentOrderCommand.kt
@@ -1,7 +1,6 @@
 package org.collaborators.paymentslab.payment.application.command
 
 data class PaymentOrderCommand(
-    val accountId: Long,
     val orderName: String,
     val amount: Int
 )

--- a/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/command/PaymentOrderCommand.kt
+++ b/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/command/PaymentOrderCommand.kt
@@ -1,0 +1,7 @@
+package org.collaborators.paymentslab.payment.application.command
+
+data class PaymentOrderCommand(
+    val accountId: Long,
+    val orderName: String,
+    val amount: Int
+)

--- a/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/command/PaymentOrderCommand.kt
+++ b/payment-api/payment-application/src/main/kotlin/org/collaborators/paymentslab/payment/application/command/PaymentOrderCommand.kt
@@ -1,6 +1,7 @@
 package org.collaborators.paymentslab.payment.application.command
 
 data class PaymentOrderCommand(
+    val accountId: Long,
     val orderName: String,
     val amount: Int
 )

--- a/payment-api/payment-domain/src/main/kotlin/org/collaborators/paymentslab/payment/domain/PaymentOrderProcessor.kt
+++ b/payment-api/payment-domain/src/main/kotlin/org/collaborators/paymentslab/payment/domain/PaymentOrderProcessor.kt
@@ -1,5 +1,5 @@
 package org.collaborators.paymentslab.payment.domain
 
 interface PaymentOrderProcessor {
-    fun process(orderName: String, amount: Int): String
+    fun process(accountId: Long, orderName: String, amount: Int): String
 }

--- a/payment-api/payment-domain/src/main/kotlin/org/collaborators/paymentslab/payment/domain/PaymentOrderProcessor.kt
+++ b/payment-api/payment-domain/src/main/kotlin/org/collaborators/paymentslab/payment/domain/PaymentOrderProcessor.kt
@@ -1,5 +1,5 @@
 package org.collaborators.paymentslab.payment.domain
 
 interface PaymentOrderProcessor {
-    fun process(accountId: Long, orderName: String, amount: Int): String
+    fun process(orderName: String, amount: Int): String
 }

--- a/payment-api/payment-domain/src/main/kotlin/org/collaborators/paymentslab/payment/domain/PaymentOrderProcessor.kt
+++ b/payment-api/payment-domain/src/main/kotlin/org/collaborators/paymentslab/payment/domain/PaymentOrderProcessor.kt
@@ -1,0 +1,5 @@
+package org.collaborators.paymentslab.payment.domain
+
+interface PaymentOrderProcessor {
+    fun process(accountId: Long, orderName: String, amount: Int): String
+}

--- a/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/PaymentModuleConfiguration.kt
+++ b/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/PaymentModuleConfiguration.kt
@@ -10,10 +10,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer
 import org.collaborators.paymentslab.payment.infrastructure.jpa.PaymentOrderRepositoryAdapter
 import org.collaborators.paymentslab.payment.infrastructure.jpa.TossPaymentHistoryRepositoryAdapter
 import org.collaborators.paymentslab.payment.infrastructure.jpa.TossPaymentsRepositoryAdapter
-import org.collaborators.paymentslab.payment.infrastructure.tosspayments.TossPaymentsProcessor
-import org.collaborators.paymentslab.payment.infrastructure.tosspayments.TossPaymentsKeyInApprovalProcessor
-import org.collaborators.paymentslab.payment.infrastructure.tosspayments.TossPaymentsQueryManager
-import org.collaborators.paymentslab.payment.infrastructure.tosspayments.TossPaymentsValidator
+import org.collaborators.paymentslab.payment.infrastructure.tosspayments.*
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
@@ -31,6 +28,7 @@ import java.time.format.DateTimeFormatter
     TossPaymentsQueryManager::class,
     TossPaymentsValidator::class,
     TossPaymentsKeyInApprovalProcessor::class,
+    TossPaymentsPaymentOrderProcessor::class,
 ])
 @Configuration
 class PaymentModuleConfiguration

--- a/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsPaymentOrderProcessor.kt
+++ b/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsPaymentOrderProcessor.kt
@@ -1,21 +1,27 @@
 package org.collaborators.paymentslab.payment.infrastructure.tosspayments
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.collaborator.paymentlab.common.AuthenticatedUser
 import org.collaborators.paymentslab.payment.domain.PaymentOrderProcessor
 import org.collaborators.paymentslab.payment.domain.entity.PaymentOrder
 import org.collaborators.paymentslab.payment.domain.repository.PaymentOrderRepository
 import org.collaborators.paymentslab.payment.infrastructure.tosspayments.exception.InvalidPaymentOrderException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.security.core.context.SecurityContextHolder
 
 class TossPaymentsPaymentOrderProcessor(
     private val paymentOrderRepository: PaymentOrderRepository
 ): PaymentOrderProcessor {
+
     override fun process(accountId: Long, orderName: String, amount: Int): String {
         val principal = SecurityContextHolder.getContext().authentication.principal as AuthenticatedUser
         if (accountId != principal.id)
             throw InvalidPaymentOrderException()
         val newPaymentOrder = PaymentOrder.newInstance(accountId, orderName, amount)
         paymentOrderRepository.save(newPaymentOrder)
+
         return newPaymentOrder.id.toString()
     }
 }

--- a/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsPaymentOrderProcessor.kt
+++ b/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsPaymentOrderProcessor.kt
@@ -1,0 +1,21 @@
+package org.collaborators.paymentslab.payment.infrastructure.tosspayments
+
+import org.collaborator.paymentlab.common.AuthenticatedUser
+import org.collaborators.paymentslab.payment.domain.PaymentOrderProcessor
+import org.collaborators.paymentslab.payment.domain.entity.PaymentOrder
+import org.collaborators.paymentslab.payment.domain.repository.PaymentOrderRepository
+import org.collaborators.paymentslab.payment.infrastructure.tosspayments.exception.InvalidPaymentOrderException
+import org.springframework.security.core.context.SecurityContextHolder
+
+class TossPaymentsPaymentOrderProcessor(
+    private val paymentOrderRepository: PaymentOrderRepository
+): PaymentOrderProcessor {
+    override fun process(accountId: Long, orderName: String, amount: Int): String {
+        val principal = SecurityContextHolder.getContext().authentication.principal as AuthenticatedUser
+        if (accountId != principal.id)
+            throw InvalidPaymentOrderException()
+        val newPaymentOrder = PaymentOrder.newInstance(accountId, orderName, amount)
+        paymentOrderRepository.save(newPaymentOrder)
+        return newPaymentOrder.id.toString()
+    }
+}

--- a/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsPaymentOrderProcessor.kt
+++ b/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsPaymentOrderProcessor.kt
@@ -10,7 +10,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 class TossPaymentsPaymentOrderProcessor(
     private val paymentOrderRepository: PaymentOrderRepository
 ): PaymentOrderProcessor {
-    override fun process(orderName: String, amount: Int): String {
+    override fun process(accountId: Long, orderName: String, amount: Int): String {
         val principal = SecurityContextHolder.getContext().authentication.principal as AuthenticatedUser
         // TODO 프론트에 jwt 토큰 값을 파싱하는 기능을 추가하기 전까지만 비활성화
 //        if (accountId != principal.id)

--- a/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsPaymentOrderProcessor.kt
+++ b/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsPaymentOrderProcessor.kt
@@ -10,11 +10,12 @@ import org.springframework.security.core.context.SecurityContextHolder
 class TossPaymentsPaymentOrderProcessor(
     private val paymentOrderRepository: PaymentOrderRepository
 ): PaymentOrderProcessor {
-    override fun process(accountId: Long, orderName: String, amount: Int): String {
+    override fun process(orderName: String, amount: Int): String {
         val principal = SecurityContextHolder.getContext().authentication.principal as AuthenticatedUser
-        if (accountId != principal.id)
-            throw InvalidPaymentOrderException()
-        val newPaymentOrder = PaymentOrder.newInstance(accountId, orderName, amount)
+        // TODO 프론트에 jwt 토큰 값을 파싱하는 기능을 추가하기 전까지만 비활성화
+//        if (accountId != principal.id)
+//            throw InvalidPaymentOrderException()
+        val newPaymentOrder = PaymentOrder.newInstance(principal.id, orderName, amount)
         paymentOrderRepository.save(newPaymentOrder)
         return newPaymentOrder.id.toString()
     }

--- a/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsPaymentOrderProcessor.kt
+++ b/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsPaymentOrderProcessor.kt
@@ -12,10 +12,9 @@ class TossPaymentsPaymentOrderProcessor(
 ): PaymentOrderProcessor {
     override fun process(accountId: Long, orderName: String, amount: Int): String {
         val principal = SecurityContextHolder.getContext().authentication.principal as AuthenticatedUser
-        // TODO 프론트에 jwt 토큰 값을 파싱하는 기능을 추가하기 전까지만 비활성화
-//        if (accountId != principal.id)
-//            throw InvalidPaymentOrderException()
-        val newPaymentOrder = PaymentOrder.newInstance(principal.id, orderName, amount)
+        if (accountId != principal.id)
+            throw InvalidPaymentOrderException()
+        val newPaymentOrder = PaymentOrder.newInstance(accountId, orderName, amount)
         paymentOrderRepository.save(newPaymentOrder)
         return newPaymentOrder.id.toString()
     }

--- a/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsValidator.kt
+++ b/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsValidator.kt
@@ -6,7 +6,8 @@ import org.collaborators.paymentslab.payment.domain.entity.PaymentsStatus
 import org.collaborators.paymentslab.payment.infrastructure.tosspayments.exception.*
 import org.slf4j.LoggerFactory
 import org.springframework.security.core.context.SecurityContextHolder
-import java.util.*
+import java.util.Locale
+
 
 class TossPaymentsValidator {
     private val log = LoggerFactory.getLogger(this::class.java)

--- a/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsValidator.kt
+++ b/payment-api/payment-infrastructure/src/main/kotlin/org/collaborators/paymentslab/payment/infrastructure/tosspayments/TossPaymentsValidator.kt
@@ -6,41 +6,46 @@ import org.collaborators.paymentslab.payment.domain.entity.PaymentsStatus
 import org.collaborators.paymentslab.payment.infrastructure.tosspayments.exception.*
 import org.slf4j.LoggerFactory
 import org.springframework.security.core.context.SecurityContextHolder
+import java.util.*
 
 class TossPaymentsValidator {
     private val log = LoggerFactory.getLogger(this::class.java)
 
+    private val statusToException = mapOf(
+        PaymentsStatus.IN_PROGRESS to AlreadyInProgressPaymentOrderException(),
+        PaymentsStatus.DONE to AlreadyDonePaymentOrderException(),
+        PaymentsStatus.CANCELED to AlreadyCanceledPaymentOrderException(),
+        PaymentsStatus.ABORTED to AlreadyAbortedPaymentOrderException()
+    )
+
     fun validate(paymentOrder: PaymentOrder, amount: Int, orderName: String) {
         val accountUser = SecurityContextHolder.getContext().authentication.principal as AuthenticatedUser
-        val paymentOrderId = paymentOrder.id
 
-        if (paymentOrder.accountId != accountUser.id) {
-            log.error("invalid accountId from paymentOrderId {}", paymentOrderId)
-            throw InvalidPaymentOrderAccountIdException()
-        }
-        if (paymentOrder.amount != amount
-            || paymentOrder.orderName != orderName
-            || !PaymentsStatus.isInRange(paymentOrder.status)
-        ) {
-            log.error("invalid amount from paymentOrderId {}", paymentOrderId)
-            throw InvalidPaymentOrderException()
-        }
+        checkAccountId(paymentOrder, accountUser.id)
+        checkPaymentDetails(paymentOrder, amount, orderName)
+        checkPaymentStatus(paymentOrder)
+    }
 
-        if (paymentOrder.status == PaymentsStatus.IN_PROGRESS) {
-            log.error("already in progress paymentOrderId {}", paymentOrderId)
-            throw AlreadyInProgressPaymentOrderException()
+    private fun checkAccountId(paymentOrder: PaymentOrder, accountId: Long) {
+        if (paymentOrder.accountId != accountId) {
+            logAndThrow("invalid accountId from paymentOrderId ${paymentOrder.id}", InvalidPaymentOrderAccountIdException())
         }
-        if (paymentOrder.status == PaymentsStatus.DONE) {
-            log.error("already done paymentOrderId {}", paymentOrderId)
-            throw AlreadyDonePaymentOrderException()
+    }
+
+    private fun checkPaymentDetails(paymentOrder: PaymentOrder, amount: Int, orderName: String) {
+        if (paymentOrder.amount != amount || paymentOrder.orderName != orderName || !PaymentsStatus.isInRange(paymentOrder.status)) {
+            logAndThrow("invalid amount from paymentOrderId ${paymentOrder.id}", InvalidPaymentOrderException())
         }
-        if (paymentOrder.status == PaymentsStatus.CANCELED) {
-            log.error("already canceled paymentOrderId {}", paymentOrderId)
-            throw AlreadyCanceledPaymentOrderException()
+    }
+
+    private fun checkPaymentStatus(paymentOrder: PaymentOrder) {
+        statusToException[paymentOrder.status]?.let {
+            logAndThrow("already ${paymentOrder.status.name.lowercase(Locale.getDefault())} paymentOrderId ${paymentOrder.id}", it)
         }
-        if (paymentOrder.status == PaymentsStatus.ABORTED) {
-            log.error("already aborted paymentOrderId {}", paymentOrderId)
-            throw AlreadyAbortedPaymentOrderException()
-        }
+    }
+
+    private fun logAndThrow(message: String, exception: RuntimeException) {
+        log.error(message)
+        throw exception
     }
 }

--- a/payment-api/payment-presentation/build.gradle.kts
+++ b/payment-api/payment-presentation/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
+++ b/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
@@ -1,6 +1,7 @@
 package org.collaborators.paymentslab.payment.presentation
 
 import jakarta.validation.Valid
+import org.collaborator.paymentlab.common.V1_API_TOSS_PAYMENTS
 import org.collaborator.paymentlab.common.result.ApiResult
 import org.collaborators.paymentslab.payment.application.PaymentService
 import org.collaborators.paymentslab.payment.application.query.PaymentHistoryQuery
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.*
 import java.net.URI
 
 @RestController
-@RequestMapping("api/v1/toss-payments")
+@RequestMapping(V1_API_TOSS_PAYMENTS)
 class PaymentApi(private val paymentService: PaymentService) {
 
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")

--- a/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
+++ b/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
@@ -4,6 +4,7 @@ import jakarta.validation.Valid
 import org.collaborator.paymentlab.common.V1_API_TOSS_PAYMENTS
 import org.collaborator.paymentlab.common.V1_TOSS_PAYMENTS
 import org.collaborator.paymentlab.common.result.ApiResult
+import org.collaborators.paymentslab.payment.application.PaymentOrderService
 import org.collaborators.paymentslab.payment.application.PaymentService
 import org.collaborators.paymentslab.payment.application.query.PaymentHistoryQuery
 import org.collaborators.paymentslab.payment.presentation.request.PaymentOrderRequest
@@ -24,7 +25,10 @@ import java.net.URI
 
 @RestController
 @RequestMapping(V1_API_TOSS_PAYMENTS)
-class PaymentApi(private val paymentService: PaymentService) {
+class PaymentApi(
+    private val paymentService: PaymentService,
+    private val paymentOrderService: PaymentOrderService
+    ) {
 
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @PostMapping("key-in/{paymentOrderId}")
@@ -40,15 +44,14 @@ class PaymentApi(private val paymentService: PaymentService) {
     fun generatePaymentOrder(
         @RequestBody @Valid request: PaymentOrderRequest
     ): ResponseEntity<Void> {
-        val paymentOrderId = paymentService.generatePaymentOrder(request.toCommand())
+        val paymentOrderId = paymentOrderService.generate(request.toCommand())
         return ResponseEntity.status(HttpStatus.SEE_OTHER).location(URI("http://localhost:8080$V1_API_TOSS_PAYMENTS/${paymentOrderId}")).build()
     }
 
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @GetMapping("{paymentOrderId}")
-    fun getPaymentOrderId(@PathVariable paymentOrderId: Long) {
-        // TODO 결제 주문 페이지 작업 진행하기
-        println("paymentOrderId : $paymentOrderId")
+    fun getPaymentOrderId(@PathVariable paymentOrderId: Long): ResponseEntity<String> {
+        return ResponseEntity.ok(paymentOrderId.toString())
     }
 
 

--- a/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
+++ b/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
@@ -2,17 +2,24 @@ package org.collaborators.paymentslab.payment.presentation
 
 import jakarta.validation.Valid
 import org.collaborator.paymentlab.common.V1_API_TOSS_PAYMENTS
+import org.collaborator.paymentlab.common.V1_TOSS_PAYMENTS
 import org.collaborator.paymentlab.common.result.ApiResult
 import org.collaborators.paymentslab.payment.application.PaymentService
 import org.collaborators.paymentslab.payment.application.query.PaymentHistoryQuery
 import org.collaborators.paymentslab.payment.presentation.request.PaymentOrderRequest
 import org.collaborators.paymentslab.payment.presentation.request.TossPaymentsKeyInRequest
 import org.collaborators.paymentslab.payment.presentation.response.PaymentHistoryResponse
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestBody
+
 import java.net.URI
 
 @RestController
@@ -34,7 +41,7 @@ class PaymentApi(private val paymentService: PaymentService) {
         @RequestBody @Valid request: PaymentOrderRequest
     ): ResponseEntity<Void> {
         val paymentOrderId = paymentService.generatePaymentOrder(request.toCommand())
-        return ResponseEntity.status(HttpStatus.SEE_OTHER).location(URI("/api/v1/toss-payments/${paymentOrderId}")).build()
+        return ResponseEntity.status(HttpStatus.SEE_OTHER).location(URI("$V1_TOSS_PAYMENTS/payment-order/${paymentOrderId}")).build()
     }
 
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")

--- a/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
+++ b/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
@@ -41,7 +41,7 @@ class PaymentApi(private val paymentService: PaymentService) {
         @RequestBody @Valid request: PaymentOrderRequest
     ): ResponseEntity<Void> {
         val paymentOrderId = paymentService.generatePaymentOrder(request.toCommand())
-        return ResponseEntity.status(HttpStatus.SEE_OTHER).location(URI("$V1_TOSS_PAYMENTS/payment-order/${paymentOrderId}")).build()
+        return ResponseEntity.status(HttpStatus.SEE_OTHER).location(URI("http://localhost:8080$V1_API_TOSS_PAYMENTS/${paymentOrderId}")).build()
     }
 
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")

--- a/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
+++ b/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
@@ -4,6 +4,7 @@ import jakarta.validation.Valid
 import org.collaborator.paymentlab.common.result.ApiResult
 import org.collaborators.paymentslab.payment.application.PaymentService
 import org.collaborators.paymentslab.payment.application.query.PaymentHistoryQuery
+import org.collaborators.paymentslab.payment.presentation.request.PaymentOrderRequest
 import org.collaborators.paymentslab.payment.presentation.request.TossPaymentsKeyInRequest
 import org.collaborators.paymentslab.payment.presentation.response.PaymentHistoryResponse
 import org.springframework.http.HttpHeaders
@@ -31,9 +32,17 @@ class PaymentApi(private val paymentService: PaymentService) {
     fun generatePaymentOrder(
         @RequestBody @Valid request: PaymentOrderRequest
     ): ResponseEntity<Void> {
-        val paymentOrderId = paymentService.generatePaymentOrder()
+        val paymentOrderId = paymentService.generatePaymentOrder(request.toCommand())
         return ResponseEntity.status(HttpStatus.SEE_OTHER).location(URI("/api/v1/toss-payments/${paymentOrderId}")).build()
     }
+
+    @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
+    @GetMapping("{paymentOrderId}")
+    fun getPaymentOrderId(@PathVariable paymentOrderId: Long) {
+        // TODO 결제 주문 페이지 작업 진행하기
+        println("paymentOrderId : $paymentOrderId")
+    }
+
 
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @GetMapping

--- a/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
+++ b/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentApi.kt
@@ -6,8 +6,12 @@ import org.collaborators.paymentslab.payment.application.PaymentService
 import org.collaborators.paymentslab.payment.application.query.PaymentHistoryQuery
 import org.collaborators.paymentslab.payment.presentation.request.TossPaymentsKeyInRequest
 import org.collaborators.paymentslab.payment.presentation.response.PaymentHistoryResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
+import java.net.URI
 
 @RestController
 @RequestMapping("api/v1/toss-payments")
@@ -20,6 +24,15 @@ class PaymentApi(private val paymentService: PaymentService) {
         @RequestBody @Valid request: TossPaymentsKeyInRequest
     ) {
         paymentService.keyInPay(paymentOrderId, request.toCommand())
+    }
+
+    @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
+    @PostMapping("payment-order")
+    fun generatePaymentOrder(
+        @RequestBody @Valid request: PaymentOrderRequest
+    ): ResponseEntity<Void> {
+        val paymentOrderId = paymentService.generatePaymentOrder()
+        return ResponseEntity.status(HttpStatus.SEE_OTHER).location(URI("/api/v1/toss-payments/${paymentOrderId}")).build()
     }
 
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")

--- a/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentController.kt
+++ b/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/PaymentController.kt
@@ -1,0 +1,16 @@
+package org.collaborators.paymentslab.payment.presentation
+
+import org.collaborator.paymentlab.common.V1_TOSS_PAYMENTS
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Controller
+@RequestMapping(V1_TOSS_PAYMENTS)
+class PaymentController {
+    @GetMapping
+    fun purchasePage(model: Model): String {
+        return "purchase"
+    }
+}

--- a/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/request/PaymentOrderRequest.kt
+++ b/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/request/PaymentOrderRequest.kt
@@ -1,0 +1,13 @@
+package org.collaborators.paymentslab.payment.presentation.request
+
+import org.collaborators.paymentslab.payment.application.command.PaymentOrderCommand
+
+data class PaymentOrderRequest(
+    val accountId: Long,
+    val orderName: String,
+    val amount: Int
+) {
+    fun toCommand(): PaymentOrderCommand {
+        return PaymentOrderCommand(accountId, orderName, amount)
+    }
+}

--- a/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/request/PaymentOrderRequest.kt
+++ b/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/request/PaymentOrderRequest.kt
@@ -3,11 +3,10 @@ package org.collaborators.paymentslab.payment.presentation.request
 import org.collaborators.paymentslab.payment.application.command.PaymentOrderCommand
 
 data class PaymentOrderRequest(
-    val accountId: Long,
     val orderName: String,
     val amount: Int
 ) {
     fun toCommand(): PaymentOrderCommand {
-        return PaymentOrderCommand(accountId, orderName, amount)
+        return PaymentOrderCommand(orderName, amount)
     }
 }

--- a/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/request/PaymentOrderRequest.kt
+++ b/payment-api/payment-presentation/src/main/kotlin/org/collaborators/paymentslab/payment/presentation/request/PaymentOrderRequest.kt
@@ -3,10 +3,11 @@ package org.collaborators.paymentslab.payment.presentation.request
 import org.collaborators.paymentslab.payment.application.command.PaymentOrderCommand
 
 data class PaymentOrderRequest(
+    val accountId: Long,
     val orderName: String,
     val amount: Int
 ) {
     fun toCommand(): PaymentOrderCommand {
-        return PaymentOrderCommand(orderName, amount)
+        return PaymentOrderCommand(accountId, orderName, amount)
     }
 }


### PR DESCRIPTION
카프카 학습에 집중하기 위해 프로젝트 작업의 경우, 
기존 코드 리팩토링 및 멱등키 생성에 사용되는 결제 주문(paymentOrder) 발행 api를 구현해보았습니다.

시간이 허락된다면, 간단한 퍼블리싱을 적용하여, 직접 주문 결제(상품 상세 페이지에서 옵션을 정하고, '바로 결제하기'를 선택하는 상황)를
수행할 수 있는 기능도 추가하고 merge 해보겠습니다.