### PR TITLE
Continuous Delivery Task 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
         
         - name: Deploy
           run: |
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'pid=$(ps axww | grep -v grep | grep "app-0.0.1.jar" | awk "{print \$1}"); if [ -n "$pid" ]; then sudo kill -9 $pid; fi'
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'ps axww | grep -v grep | grep "app-0.0.1.jar" | awk '{print $1}' | xargs -r sudo kill -9'
             ssh nrunner@${{ secrets.APP_MAIN_SERVER }} '[[ -f ~/app-0.0.1.jar ]] && rm -rf ~/app-0.0.1.jar'
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'mv ./payment-lab/app/build/libs/app-0.0.1.jar ~/'
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'nohup java -Dspring.profiles.active=dev -DadminKey=${{ secrets.APP_ADMIN_KEY }} -jar ~/app-0.0.1.jar > /dev/null 2>&1 &'
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'mv ./payment-lab/app/build/libs/app-0.0.1.jar ~/app-0.0.1.jar'
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'sudo nohup java -Dspring.profiles.active=dev -DadminKey=${{ secrets.APP_ADMIN_KEY }} -jar ~/app-0.0.1.jar > /dev/null 2>&1 &'
             ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'rm -rf ./payment-lab'
             ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'echo "Application started"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,25 +36,25 @@ jobs:
         - name: SSH to server
           run: |
             ssh-keyscan -H ${{ secrets.APP_MAIN_SERVER }} >> ~/.ssh/known_hosts
-            ssh -o StrictHostKeyChecking=no nrunner@${{ secrets.APP_MAIN_SERVER }} exit
+            ssh -o StrictHostKeyChecking=no ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} exit
         
         - name: clone repository
-          run: ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'git clone https://github.com/wanniDev/payment-lab'
+          run: ssh ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} 'git clone https://github.com/wanniDev/payment-lab'
 
         - name: Inject property files
           run: |
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'mkdir -p ./payment-lab/app/src/main/resources/'
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-dev.yml ]] && echo "${{ secrets.APP_PROPS_DEV }}" > ./payment-lab/app/src/main/resources/application-dev.yml'
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-test.yml ]] && echo "${{ secrets.APP_PROPS }}" > ./payment-lab/app/src/main/resources/application-test.yml'
+            ssh ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} 'mkdir -p ./payment-lab/app/src/main/resources/'
+            ssh ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-dev.yml ]] && echo "${{ secrets.APP_PROPS_DEV }}" > ./payment-lab/app/src/main/resources/application-dev.yml'
+            ssh ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-test.yml ]] && echo "${{ secrets.APP_PROPS }}" > ./payment-lab/app/src/main/resources/application-test.yml'
         
         - name: Build application
-          run: ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'chmod +x ./payment-lab/gradlew; cd ./payment-lab && ./gradlew clean build'
+          run: ssh ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} 'chmod +x ./payment-lab/gradlew; cd ./payment-lab && ./gradlew clean build'
         
         - name: Deploy
           run: |
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'ps axww | grep -v grep | grep "app-0.0.1.jar" | awk '{print $1}' | xargs -r sudo kill -9'
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} '[[ -f ~/app-0.0.1.jar ]] && rm -rf ~/app-0.0.1.jar'
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'mv ./payment-lab/app/build/libs/app-0.0.1.jar ~/app-0.0.1.jar'
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'sudo nohup java -Dspring.profiles.active=dev -DadminKey=${{ secrets.APP_ADMIN_KEY }} -jar ~/app-0.0.1.jar > /dev/null 2>&1 &'
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'rm -rf ./payment-lab'
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'echo "Application started"'
+            ssh ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} 'ps axww | grep -v grep | grep "app-0.0.1.jar" | awk '{print $1}' | xargs -r sudo kill -9'
+            ssh ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} '[[ -f ~/app-0.0.1.jar ]] && rm -rf ~/app-0.0.1.jar'
+            ssh ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} 'mv ./payment-lab/app/build/libs/app-0.0.1.jar ~/app-0.0.1.jar'
+            ssh ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} 'sudo nohup java -Dspring.profiles.active=dev -DadminKey=${{ secrets.APP_ADMIN_KEY }} -jar ~/app-0.0.1.jar > /dev/null 2>&1 &'
+            ssh ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} 'rm -rf ./payment-lab'
+            ssh ${{ secrets.APP_RUNNER }}@${{ secrets.APP_MAIN_SERVER }} 'echo "Application started"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,27 +32,29 @@ jobs:
           uses: webfactory/ssh-agent@v0.8.0
           with:
             ssh-private-key: ${{ secrets.APP_RUNNER_PRIVATE_KEY }}
+        - run: |
+            ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'git clone https://github.com/wanniDev/payment-lab'
 
-        - name: SSH to server
-          run: |
-            ssh-keyscan -H ${{ secrets.APP_MAIN_SERVER }} >> ~/.ssh/known_hosts
-            ssh -o StrictHostKeyChecking=no nruuner@${{ secrets.APP_MAIN_SERVER }} exit
+        # - name: SSH to server
+        #   run: |
+        #     ssh-keyscan -H ${{ secrets.APP_MAIN_SERVER }} >> ~/.ssh/known_hosts
+        #     ssh -o StrictHostKeyChecking=no nruuner@${{ secrets.APP_MAIN_SERVER }} exit
         
-        - name: clone repository
-          run: ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'git clone https://github.com/wanniDev/payment-lab'
+        # - name: clone repository
+        #   run: ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'git clone https://github.com/wanniDev/payment-lab'
 
-        - name: Inject property files
-          run: |
-            ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'mkdir -p ./payment-lab/app/src/main/resources/'
-            ssh nruuner@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-dev.yml ]] && echo "${{ secrets.APP_PROPS_DEV }}" > ./payment-lab/app/src/main/resources/application-dev.yml'
-            ssh nruuner@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-test.yml ]] && echo "${{ secrets.APP_PROPS }}" > ./payment-lab/app/src/main/resources/application-test.yml'
+        # - name: Inject property files
+        #   run: |
+        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'mkdir -p ./payment-lab/app/src/main/resources/'
+        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-dev.yml ]] && echo "${{ secrets.APP_PROPS_DEV }}" > ./payment-lab/app/src/main/resources/application-dev.yml'
+        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-test.yml ]] && echo "${{ secrets.APP_PROPS }}" > ./payment-lab/app/src/main/resources/application-test.yml'
         
-        - name: Build application
-          run: ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'chmod +x ./payment-lab/gradlew; cd ./payment-lab && ./gradlew clean build'
+        # - name: Build application
+        #   run: ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'chmod +x ./payment-lab/gradlew; cd ./payment-lab && ./gradlew clean build'
         
-        - name: Deploy
-          run: |
-            ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'pid=$(ps axww | grep -v grep | grep "./app/build/libs/app-0.0.1.jar" | awk "{print \$1}"); if [ -n "$pid" ]; then kill -9 $pid; fi'
-            ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'mv ./payment-lab/app/build/libs/app-0.0.1.jar ~/'
-            ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'nohup java -Dspring.profiles.active=dev -DadminKey=${{ secrets.APP_ADMIN_KEY }} -jar ~/app-0.0.1.jar > /dev/null 2>&1 &'
-            ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'echo "Application started"'
+        # - name: Deploy
+        #   run: |
+        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'pid=$(ps axww | grep -v grep | grep "./app/build/libs/app-0.0.1.jar" | awk "{print \$1}"); if [ -n "$pid" ]; then kill -9 $pid; fi'
+        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'mv ./payment-lab/app/build/libs/app-0.0.1.jar ~/'
+        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'nohup java -Dspring.profiles.active=dev -DadminKey=${{ secrets.APP_ADMIN_KEY }} -jar ~/app-0.0.1.jar > /dev/null 2>&1 &'
+        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'echo "Application started"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,16 @@ jobs:
       steps:
         - name: checkout
           uses: actions/checkout@v3
-
+        
         - name: set up ssh
           uses: webfactory/ssh-agent@v0.8.0
           with:
             ssh-private-key: ${{ secrets.APP_RUNNER_PRIVATE_KEY }}
+
+        - name: SSH to server
+          run: |
+            ssh-keyscan -H ${{ secrets.APP_MAIN_SERVER }} >> ~/.ssh/known_hosts
+            ssh -o StrictHostKeyChecking=no nruuner@${{ secrets.APP_MAIN_SERVER }} exit
         
         - name: clone repository
           run: ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'git clone https://github.com/wanniDev/payment-lab'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         - name: Deploy
           run: |
             ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'pid=$(ps axww | grep -v grep | grep "./app/build/libs/app-0.0.1.jar" | awk "{print \$1}"); if [ -n "$pid" ]; then kill -9 $pid; fi'
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} '[[ -f ~/app-0.0.1.jar ]] && rm -rf ~/app-0.0.1.jar'
             ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'mv ./payment-lab/app/build/libs/app-0.0.1.jar ~/'
             ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'nohup java -Dspring.profiles.active=dev -DadminKey=${{ secrets.APP_ADMIN_KEY }} -jar ~/app-0.0.1.jar > /dev/null 2>&1 &'
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'rm -rf ./payment-lab'
             ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'echo "Application started"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         
         - name: Deploy
           run: |
-            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'pid=$(ps axww | grep -v grep | grep "./app/build/libs/app-0.0.1.jar" | awk "{print \$1}"); if [ -n "$pid" ]; then kill -9 $pid; fi'
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'pid=$(ps axww | grep -v grep | grep "app-0.0.1.jar" | awk "{print \$1}"); if [ -n "$pid" ]; then sudo kill -9 $pid; fi'
             ssh nrunner@${{ secrets.APP_MAIN_SERVER }} '[[ -f ~/app-0.0.1.jar ]] && rm -rf ~/app-0.0.1.jar'
             ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'mv ./payment-lab/app/build/libs/app-0.0.1.jar ~/'
             ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'nohup java -Dspring.profiles.active=dev -DadminKey=${{ secrets.APP_ADMIN_KEY }} -jar ~/app-0.0.1.jar > /dev/null 2>&1 &'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,29 +32,27 @@ jobs:
           uses: webfactory/ssh-agent@v0.8.0
           with:
             ssh-private-key: ${{ secrets.APP_RUNNER_PRIVATE_KEY }}
-        - run: |
-            ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'git clone https://github.com/wanniDev/payment-lab'
 
-        # - name: SSH to server
-        #   run: |
-        #     ssh-keyscan -H ${{ secrets.APP_MAIN_SERVER }} >> ~/.ssh/known_hosts
-        #     ssh -o StrictHostKeyChecking=no nruuner@${{ secrets.APP_MAIN_SERVER }} exit
+        - name: SSH to server
+          run: |
+            ssh-keyscan -H ${{ secrets.APP_MAIN_SERVER }} >> ~/.ssh/known_hosts
+            ssh -o StrictHostKeyChecking=no nrunner@${{ secrets.APP_MAIN_SERVER }} exit
         
-        # - name: clone repository
-        #   run: ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'git clone https://github.com/wanniDev/payment-lab'
+        - name: clone repository
+          run: ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'git clone https://github.com/wanniDev/payment-lab'
 
-        # - name: Inject property files
-        #   run: |
-        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'mkdir -p ./payment-lab/app/src/main/resources/'
-        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-dev.yml ]] && echo "${{ secrets.APP_PROPS_DEV }}" > ./payment-lab/app/src/main/resources/application-dev.yml'
-        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-test.yml ]] && echo "${{ secrets.APP_PROPS }}" > ./payment-lab/app/src/main/resources/application-test.yml'
+        - name: Inject property files
+          run: |
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'mkdir -p ./payment-lab/app/src/main/resources/'
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-dev.yml ]] && echo "${{ secrets.APP_PROPS_DEV }}" > ./payment-lab/app/src/main/resources/application-dev.yml'
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} '[[ ! -f ./payment-lab/app/src/main/resources/application-test.yml ]] && echo "${{ secrets.APP_PROPS }}" > ./payment-lab/app/src/main/resources/application-test.yml'
         
-        # - name: Build application
-        #   run: ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'chmod +x ./payment-lab/gradlew; cd ./payment-lab && ./gradlew clean build'
+        - name: Build application
+          run: ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'chmod +x ./payment-lab/gradlew; cd ./payment-lab && ./gradlew clean build'
         
-        # - name: Deploy
-        #   run: |
-        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'pid=$(ps axww | grep -v grep | grep "./app/build/libs/app-0.0.1.jar" | awk "{print \$1}"); if [ -n "$pid" ]; then kill -9 $pid; fi'
-        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'mv ./payment-lab/app/build/libs/app-0.0.1.jar ~/'
-        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'nohup java -Dspring.profiles.active=dev -DadminKey=${{ secrets.APP_ADMIN_KEY }} -jar ~/app-0.0.1.jar > /dev/null 2>&1 &'
-        #     ssh nruuner@${{ secrets.APP_MAIN_SERVER }} 'echo "Application started"'
+        - name: Deploy
+          run: |
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'pid=$(ps axww | grep -v grep | grep "./app/build/libs/app-0.0.1.jar" | awk "{print \$1}"); if [ -n "$pid" ]; then kill -9 $pid; fi'
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'mv ./payment-lab/app/build/libs/app-0.0.1.jar ~/'
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'nohup java -Dspring.profiles.active=dev -DadminKey=${{ secrets.APP_ADMIN_KEY }} -jar ~/app-0.0.1.jar > /dev/null 2>&1 &'
+            ssh nrunner@${{ secrets.APP_MAIN_SERVER }} 'echo "Application started"'

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ app/src/main/resources/static/
 
 app/src/main/resources/application-*
 logs/
+
+# monitoring
+monitoring/prometheus/data/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,10 @@ dependencies {
 
 	/** resilience4j **/
 	implementation("io.github.resilience4j:resilience4j-spring-boot3:2.1.0")
+
+	/** monitoring **/
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 }
 
 tasks {

--- a/app/src/main/kotlin/org/collaborators/paymentslab/config/security/SecurityConfig.kt
+++ b/app/src/main/kotlin/org/collaborators/paymentslab/config/security/SecurityConfig.kt
@@ -58,6 +58,7 @@ class SecurityConfig(
             .requestMatchers(POST,"$V1_AUTH/login").permitAll()
             .requestMatchers(GET, "$V1_AUTH/confirm").permitAll()
             .requestMatchers(GET, "/actuator").permitAll()
+            .requestMatchers(GET, "/actuator/*").permitAll()
             .anyRequest().authenticated()
             .and()
             .formLogin().disable()

--- a/app/src/main/kotlin/org/collaborators/paymentslab/config/security/SecurityConfig.kt
+++ b/app/src/main/kotlin/org/collaborators/paymentslab/config/security/SecurityConfig.kt
@@ -57,6 +57,7 @@ class SecurityConfig(
             .requestMatchers(POST,"$V1_AUTH/register/admin").permitAll()
             .requestMatchers(POST,"$V1_AUTH/login").permitAll()
             .requestMatchers(GET, "$V1_AUTH/confirm").permitAll()
+            .requestMatchers(GET, "/actuator").permitAll()
             .anyRequest().authenticated()
             .and()
             .formLogin().disable()

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/monitoring/monitoring.yml
+++ b/monitoring/monitoring.yml
@@ -1,0 +1,17 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.44.0
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:9.5.2
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources

--- a/monitoring/monitoring.yml
+++ b/monitoring/monitoring.yml
@@ -6,6 +6,12 @@ services:
       - "9090:9090"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus/data:/data
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/data'
+      - '--web.enable-lifecycle'
+      - '--storage.tsdb.retention.time=20d'
 
   grafana:
     image: grafana/grafana:9.5.2

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+scrape_configs:
+  - job_name: 'payment-lab-prod'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 3s
+    scheme: https
+    static_configs:
+      - targets: ['api.wannidev.com']
+        labels:
+          application: 'payment-lab-prod-label'


### PR DESCRIPTION
이번 pr에서는 기존 코드 통합만 진행하던 github action에 delivery task를 추가했습니다.

작성한 코드를 외부 환경에서 자동으로 테스트하여 코드의 품질을 높이는 것 뿐만 아니라, 배포 과정 역시 자동화하여 배포 빈도수를 높임으로써 prod 및 dev 환경에서 발생할 수 있는 수정사항을 신속하게 찾고 추가 작업을 수행할 수 있는 환경을 만드는 것을 목표로 진행하였습니다.

현재 ncp 운영중인 서버는 dev 환경의 단일 서버로서, 제가 작성한 제품 코드가 prod와 동일한 환경에서도 제가 의도한대로 잘 돌아가는지 확인하는 것에 초점을 맞추고 있습니다. 지금은 db와 kafka가 하나의 서버에 전부 설치 되어있는데, 확장하는 과정을 거치면서 전부 분리할 예정입니다.

해당 서버에 대한 모니터링은 로컬에 도커로 설치된 프로메테우스와 그라파나를 활용하고 있습니다. 
좀 더 구체적인 확장 계획을 말씀드리면, 가장 낮은 사양의 서버를 배포하고 해당 서버의 성능, 강도 테스트를 수행하고 모니터링을 진행하며  'scale-up'을 진행하고 적절한 시점에서 reverse-proxy 기반의 load balancer를 활용하여 scale-out을 진행할 예정입니다.